### PR TITLE
Fix value being `float` instead of `number`

### DIFF
--- a/yaml/types/InputService.yaml
+++ b/yaml/types/InputService.yaml
@@ -189,7 +189,7 @@ Events:
       - Name: keycode
         Type: KeyCodeEnum
       - Name: value
-        Type: float
+        Type: number
     Description: Fires when analog input has been changed
 IsStatic: true
 IsAbstract: false


### PR DESCRIPTION
Stumbled on this while working to parse these docs into Luau LSP type definition files.
I'm not certain this isn't intentionally `float` for documentation reasons, I think it would be weird if thats the case though.