### PR TITLE
Fix `Camera:ViewportPointToRay` referencing `Vector3`

### DIFF
--- a/yaml/types/Camera.yaml
+++ b/yaml/types/Camera.yaml
@@ -183,7 +183,7 @@ Methods:
     IsAsync: false
     IsObsolete: false
     IsStatic: false
-    Description: Cast a ray from the camera at the specified ViewportPoint (Vector3
+    Description: Cast a ray from the camera at the specified ViewportPoint (Vector2
       with components with values in range of 0 - 1 describing how far a point
       is to to right and to the top of the screen) into the game world
   - Name: ScreenPointToRay


### PR DESCRIPTION
Closes #17 

This pull request fixes a copy-paste error in `Camera:ViewportPointToRay`