### PR TITLE
Clean up certain autogen admonitions

### DIFF
--- a/autogen/mdgen.js
+++ b/autogen/mdgen.js
@@ -120,10 +120,6 @@ for (const yamlFile of yamlFiles) {
         appendLine(`{{ inherited_by([${children.map(n => `"${n}"`).join(", ")}]) }}`)
     }
 
-    appendLine("")
-    appendLine(c.Description)
-    appendLine("")
-
     if (c.IsStatic) {
         appendLine("")
         appendLine(`{{ staticclass(${c.StaticAlias ? `"${c.StaticAlias}"` : ""}) }}`)
@@ -135,6 +131,10 @@ for (const yamlFile of yamlFiles) {
         appendLine("{{ notnewable() }}")
         appendLine("")
     }
+
+    appendLine("")
+    appendLine(c.Description)
+    appendLine("")
 
     const properties = c.Properties ? (Array.isArray(c.Properties) ? c.Properties : [c.Properties]) : [];
 

--- a/autogen/mdgen.js
+++ b/autogen/mdgen.js
@@ -128,14 +128,10 @@ for (const yamlFile of yamlFiles) {
         appendLine("")
         appendLine(`{{ staticclass(${c.StaticAlias ? `"${c.StaticAlias}"` : ""}) }}`)
         appendLine("")
-    }
-
-    if (c.IsAbstract) {
+    } else if (c.IsAbstract) {
         appendLine("{{ abstract() }}")
         appendLine("")
-    }
-
-    if (!c.IsInstantiable) {
+    } else if (!c.IsInstantiable) {
         appendLine("{{ notnewable() }}")
         appendLine("")
     }


### PR DESCRIPTION
These changes were made to reduce redundant clutter and bring important information to the top.

1. Make flags `IsStatic`, `IsAbstract`, and the negation of `IsInstantiable` mutually exclusive to each other. This means only one of these will render at a time. `IsInstantiable` has the lowest order.
2. Placed these admonitions above the description instead of below it.