### PR TITLE
Add rate limit warning to HttpService

### DIFF
--- a/autogen/mdgen.js
+++ b/autogen/mdgen.js
@@ -130,6 +130,11 @@ for (const yamlFile of yamlFiles) {
         appendLine("")
     }
 
+    if (c.HttpWarning) {
+        appendLine("{{ httpwarning() }}")
+        appendLine("")
+    }
+
     if (c.IsAbstract) {
         appendLine("{{ abstract() }}")
         appendLine("")

--- a/main.py
+++ b/main.py
@@ -120,6 +120,13 @@ def define_env(env):
 </div>"""
 
     @env.macro
+    def httpwarning():
+        return """<div data-search-exclude markdown>
+!!! warning "Request limit"
+    Each server has a rate limit of 90 requests per minute.
+</div>"""
+
+    @env.macro
     def service():
         return """<div data-search-exclude markdown>
 !!! example "Service Object"
@@ -142,6 +149,7 @@ def define_env(env):
 
     Additionally, it cannot be created in the creator menu or with `Instance.New()`.
 </div>"""
+
 
     @env.macro
     def serverexclusive():

--- a/yaml/types/HttpService.yaml
+++ b/yaml/types/HttpService.yaml
@@ -206,4 +206,5 @@ Events: []
 IsStatic: true
 IsAbstract: false
 IsInstantiable: false
+HttpWarning: true
 StaticAlias: Http


### PR DESCRIPTION
Added small warning to HttpService about the rate limit for servers

<img width="1263" height="867" alt="Screenshot_20260513_085405" src="https://github.com/user-attachments/assets/376c3e79-3dce-42de-b533-bbf6a391d573" />


(I am really sorry if the implementation of the warning is bad)